### PR TITLE
Fixed AsyncStorage import in a downward compatible way

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const AsyncStorage = require('react-native').AsyncStorage
+const AsyncStorage = (require('@react-native-community/async-storage') || require('react-native')).AsyncStorage
 
 function callFallbackIfFunc(fallback, callback){
   if(typeof fallback === 'function'){

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "i18next-react-native-async-storage",
   "version": "1.0.2",
   "main": "index.js",
-  "repository": "github.com/0xClpz/i18next-react-native-async-storage",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/0xClpz/i18next-react-native-async-storage.git"
+  },
   "author": "Antonio Calapez <antonio.root@gmail.com>",
   "license": "MIT",
   "keywords": [
@@ -12,5 +15,9 @@
     "i18next",
     "async-storage",
     "Asyng storage"
-  ]
+  ],
+  "bugs": {
+    "url": "https://github.com/0xClpz/i18next-react-native-async-storage/issues"
+  },
+  "homepage": "https://github.com/0xClpz/i18next-react-native-async-storage#readme"
 }


### PR DESCRIPTION
Hi @0xClpz,

as `react-native` extracted the `AsyncStorage` to its own package some time ago and I started using your 
package in a corporate gig I'm currently working at as sole developer, I wanted to add the respective changes
as a PR. As the last few months using patch-package in the repo (outside repos aren't allowed, so I had to refer to that)
were sometimes quite annoying and would break out Bamboo builds % ).

I also updated / fixed the `package.json` to correctly point to your repo, as npmjs won't find it the way it was 
(or was this intentional ? ; ).

Hope you get around to review this & publish a new version, cause, as I wrote above, `patch-package` is nifty - but in CI/CD builds sometimes annoying.

Best,

Tim.